### PR TITLE
create event series with available status

### DIFF
--- a/anniversariesGoogleCalendar.gs
+++ b/anniversariesGoogleCalendar.gs
@@ -262,12 +262,13 @@ function createCalendarEvent(calendarId, event) {
   var currentYear = new Date().getFullYear();
   var startDate = new Date(currentYear, event.date.getMonth(), event.date.getDate());
 
-  calendar.createAllDayEventSeries(
+  var series = calendar.createAllDayEventSeries(
     title,
     startDate, 
     CalendarApp.newRecurrence().addYearlyRule(),
     { description: description }
   );
+  series.setTransparency(CalendarApp.EventTransparency.TRANSPARENT)
 
   return title;
 }


### PR DESCRIPTION
By default, events and event series are created with OPAQUE transparency. I.e., you will show as busy on the day of the event. Setting the transparency to TRANSPARENT will keep you available.

see https://developers.google.com/apps-script/reference/calendar/calendar-event-series#setTransparency(EventTransparency)