### PR TITLE
Add BIRTHDAY_TITLE_POSTFIX

### DIFF
--- a/anniversariesGoogleCalendar.gs
+++ b/anniversariesGoogleCalendar.gs
@@ -30,8 +30,9 @@ const TARGET_CALENDAR_ID = 'xxxxxxxxxxxxxxxxxxx@group.calendar.google.com'; // <
 const REPORT_RECIPIENT_EMAIL = '; // <<< SET YOUR EMAIL HERE (or '' for no report)
 
 // --- Language Configuration ---
-// Prefix for birthday event titles (e.g., "Birthday"). Set to '' for no prefix.
+// Prefix/Postfix for birthday event titles (e.g., "Birthday"). Set to '' for no prefix or postfix.
 const BIRTHDAY_TITLE_PREFIX = 'Geburtstag';
+const BIRTHDAY_TITLE_POSTFIX = '';
 
 // Label before the contact resource ID in the event description. IMPORTANT: Keep the space at the end.
 const DESC_CONTACT_ID_PREFIX = "Kontakt-ID: ";
@@ -57,6 +58,7 @@ function anniversaryEvents() {
 
   Logger.log("Skriptlauf gestartet. Kalender-ID: %s, Jahr: %s", calendarId, currentYear);
   Logger.log("Konfigurierter Geburtstagstitel-Präfix: '%s'", BIRTHDAY_TITLE_PREFIX);
+  Logger.log("Konfigurierter Geburtstagstitel-Postfix: '%s'", BIRTHDAY_TITLE_POSTFIX);
 
   // 1. Ereignisse aus Google Kontakten abrufen
   var contactEvents = getAllContactsEvents();
@@ -156,6 +158,8 @@ function getAllContactsEvents() {
 
                 // Titel mit konfiguriertem Präfix erstellen
                 var birthdayTitle = (BIRTHDAY_TITLE_PREFIX ? BIRTHDAY_TITLE_PREFIX + " " : "") + name;
+                // Postfix ergänzen
+                birthdayTitle = birthdayTitle + (BIRTHDAY_TITLE_POSTFIX ? " " + BIRTHDAY_TITLE_POSTFIX : "");
 
                 // 'name' Feld hinzufügen
                 contactsEvents.push({


### PR DESCRIPTION
This pull request introduces an optional `BIRTHDAY_TITLE_POSTFIX` parameter to the calendar sync script, complementing the existing prefix parameter used for modifying event titles during synchronization.

**Why it's useful:**
The addition of a postfix allows for greater flexibility in customizing event titles. I prefer as example that the name (or a birthday icon) appears at the beginning of the title, while the word "birthday" is added at the end. By introducing a postfix, the script allows more formatting of event titles — for example: `🎂 John Doe – Birthday`. 

**Changes:**
- Added support for a postfix argument in the script configuration
- Updated title generation logic to include both prefix and postfix
- Extended logging for postfix
- Updated documentation 

Backward Compatibility:
The change is fully backward compatible — if postfix is not provided, titles will remain unchanged